### PR TITLE
Adding None DB in order to allow unit testing without any connection to a DB

### DIFF
--- a/Database/Connection.php
+++ b/Database/Connection.php
@@ -7,6 +7,8 @@
 
 namespace Sebk\SmallOrmBundle\Database;
 
+use Sebk\SmallOrmBundle\ORM\None;
+
 /**
  * Connection to database
  * TODO: need to be generalized when ORM finished
@@ -45,6 +47,9 @@ class Connection
 
     /**
      * Connect to database, use existing connection if exists
+     *
+     * NB: "None DB" existing in case of a unit tests without any connection to a database.
+     *
      * @throws ConnectionException
      */
     protected function connect()
@@ -66,13 +71,18 @@ class Connection
                     $statement = $this->pdo->prepare("create database `$this->database`;use `$this->database`;");
                     if(!$statement->execute()) {
                         $errInfo = $statement->errorInfo();
-                        throw new ConnectionException("Fail to exectue request : SQLSTATE[".$errInfo[0]."][".$errInfo[1]."] ".$errInfo[2]);
+                        throw new ConnectionException("Fail to execute request : SQLSTATE[".$errInfo[0]."][".$errInfo[1]."] ".$errInfo[2]);
                     }
                 }
                 break;
 
+            // For unit testing purpose
+            case 'none':
+                $this->pdo = new None();
+                break;
+
             default:
-                throw new ConnectionException("Database type is not developped for now");
+                throw new ConnectionException("Database type is not developed for now");
         }
     }
 
@@ -108,7 +118,7 @@ class Connection
                 $this->connect();
                 return $this->execute($sql, $params, true);
             } else {
-                throw new ConnectionException("Fail to exectue request : SQLSTATE[" . $errInfo[0] . "][" . $errInfo[1] . "] " . $errInfo[2]);
+                throw new ConnectionException("Fail to execute request : SQLSTATE[" . $errInfo[0] . "][" . $errInfo[1] . "] " . $errInfo[2]);
             }
         }
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -32,7 +32,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('type')
                                 ->isRequired()
                                 ->validate()
-                                ->ifNotInArray(array('mysql'))
+                                ->ifNotInArray(array('mysql', 'none'))
                                     ->thenInvalid('Invalid database driver "%s"')
                                 ->end()
                             ->end()

--- a/ORM/None.php
+++ b/ORM/None.php
@@ -9,8 +9,6 @@ namespace Sebk\SmallOrmBundle\ORM;
  * This class is used when you don't need to connect to the Database. The main use case is when you need to
  * do some unit tests.
  * This will prevent PDO to fail for every request.
- *
- * You can also use it to overwrite PDO methods to get any result.
  */
 class None
 {
@@ -22,6 +20,38 @@ class None
      * @return None $this   Return self object to allow other call
      */
     public function prepare($arguments)
+    {
+        return $this;
+    }
+
+    /**
+     * Generic bindValue method
+     *
+     * @param mixed $arguments  Arguments, can be anything
+     *
+     * @return None $this   Return self object to allow other call
+     */
+    public function bindValue($arguments)
+    {
+        return $this;
+    }
+
+    /**
+     * Generic execute method
+     *
+     * @return None $this   Return self object to allow other call
+     */
+    public function execute()
+    {
+        return $this;
+    }
+
+    /**
+     * Generic fetchAll method
+     *
+     * @return None $this   Return self object to allow other call
+     */
+    public function fetchAll()
     {
         return $this;
     }

--- a/ORM/None.php
+++ b/ORM/None.php
@@ -53,7 +53,7 @@ class None
      */
     public function fetchAll()
     {
-        return $this;
+        return [];
     }
 
     /**

--- a/ORM/None.php
+++ b/ORM/None.php
@@ -49,7 +49,7 @@ class None
     /**
      * Generic fetchAll method
      *
-     * @return None $this   Return self object to allow other call
+     * @return array $this   Return empty array for consistency
      */
     public function fetchAll()
     {

--- a/ORM/None.php
+++ b/ORM/None.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Sebk\SmallOrmBundle\ORM;
+
+/**
+ * Class None
+ * @package Sebk\SmallOrmBundle\ORM
+ *
+ * This class is used when you don't need to connect to the Database. The main use case is when you need to
+ * do some unit tests.
+ * This will prevent PDO to fail for every request.
+ *
+ * You can also use it to overwrite PDO methods to get any result.
+ */
+class None
+{
+    /**
+     * Generic prepare method
+     *
+     * @param mixed $arguments  Arguments, can be anything
+     *
+     * @return None $this   Return self object to allow other call
+     */
+    public function prepare($arguments)
+    {
+        return $this;
+    }
+
+    /**
+     * This is a catch-all method in order to get a predictable PDO error.
+     *
+     * @param string    $name
+     * @param mixed     $arguments
+     *
+     * @throws \PDOException
+     */
+    public function __call($name, $arguments)
+    {
+        throw new \PDOException('None DB Exception: ' . $name . ' does not exist.');
+    }
+}


### PR DESCRIPTION
### Description
For unit testing purpose (mainly), we should be able to connect to a fake DB (I think). This allow another connection than the mysql one. The class will throw an exception for every call. But this is a predictable exception.

### Configuration
You need to specify the type `none` for your connection type. Here is an example (from my config_test.yml):
```
sebk_small_orm:
    connections:
        default:
            type:     none
```